### PR TITLE
Change IP Threat View search to us isPublicIP

### DIFF
--- a/Sumo-Logic-Tools/Threat_Intelligence_Optimized/scheduled-views.txt
+++ b/Sumo-Logic-Tools/Threat_Intelligence_Optimized/scheduled-views.txt
@@ -1,7 +1,7 @@
 Index Name: threat_intel_ip_address
 *
 | parse regex "(?<ip_address>\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})" multi
-| where ip_address != "0.0.0.0" and ip_address != "127.0.0.1"
+| where(isPublicIP(ip_address))
 | lookup type, actor, raw, threatlevel as malicious_confidence from sumo://threat/cs on threat=ip_address
 | where type="ip_address" and !isNull(malicious_confidence)
 | if (isEmpty(actor), "Unassigned", actor) as Actor


### PR DESCRIPTION
After testing, isPublicIP is faster and filters out more IPs than the previous method (| where ip_address != "0.0.0.0" and ip_address != "127.0.0.1") which will use less search capacity when passed to do the lookup