### PR TITLE
Improve the csv to json conversion

### DIFF
--- a/Salesforce/sfdc_upload_lambda.py
+++ b/Salesforce/sfdc_upload_lambda.py
@@ -43,12 +43,30 @@ def httpGet(url):
 
 	return requests.get(url, headers=getAuthHeader())
 
+def mySplit(s):
+	l = []
+	length = len(s)
+	start = 0 
+	end = 0
+	while end <= length:
+		if end == length:
+			l.append(s[start:end])
+			break
+		if s[end] == ',' and s[end-1] == '"' and s[end+1] == '"':
+			l.append(s[start:end])
+			start = end+1
+			end = start
+
+		end += 1
+
+	return l
+
 def uploadLogsToSumo(log_ids):
 	for log_id in log_ids:
 		url = f"{globs["sfdc_url"]}sobjects/EventLogFile/{log_id}/LogFile"
 		response = httpGet(url)
 
-		lines = list(map(lambda splitLine: list(map(lambda s: s[1:-1], splitLine)), list(map(lambda ln: ln.split(','), response.text.splitlines()))))
+		lines = list(map(lambda splitLine: list(map(lambda s: s[1:-1], splitLine)), list(map(lambda ln: mySplit(ln), response.text.splitlines()))))
 		column_names = lines[0]
 		payload = ""
 		for line in lines[1:]:


### PR DESCRIPTION
Certain values of the BROWSER_TYPE field, such as "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36" would break the json conversion because of the comma that it has. 